### PR TITLE
Dcwither/prepare first deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.0.1-alpha.0 (2020-06-11)
+
+
+### Bug Fixes
+
+* **pre-push:** fix pre-push tests to use lerna and stream output ([0b59873](https://github.com/chanzuckerberg/lp-design-system/commit/0b5987303ad1399c5c70ce043ba9dae65a1d73d6))
+* **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
+
+
+### Features
+
+* **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
+* **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Chan Zuckerberg Initiative, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,6 @@
 {
-  "packages": ["packages/*"],
-  "version": "0.0.0"
+  "packages": [
+    "packages/*"
+  ],
+  "version": "0.0.1-alpha.0"
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "Learning Platform"
   ],
   "author": "CZI",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/chanzuckerberg/lp-design-system/issues"
   },

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.0.1-alpha.0 (2020-06-11)
+
+
+### Features
+
+* **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-components",
-  "version": "0.0.0",
+  "version": "0.0.1-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-components",
-  "version": "0.0.0",
+  "version": "0.0.1-alpha.0",
   "description": "React components for czedi-kit",
   "keywords": [
     "design system",
@@ -39,8 +39,8 @@
     "react": ">= 16.8.0"
   },
   "dependencies": {
-    "@chanzuckerberg/czedi-kit-styles": "^0.0.0",
-    "@chanzuckerberg/czedi-kit-tokens": "^0.0.0",
+    "@chanzuckerberg/czedi-kit-styles": "^0.0.1-alpha.0",
+    "@chanzuckerberg/czedi-kit-tokens": "^0.0.1-alpha.0",
     "classnames": "^2.2.6"
   },
   "devDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -8,7 +8,7 @@
   ],
   "author": "Devin Witherspoon <dcwither@gmail.com>",
   "homepage": "https://github.com/chanzuckerberg/lp-design-system/tree/master/packages/czedi-kit-components#readme",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "main": "dist/index.js",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.0.1-alpha.0 (2020-06-11)
+
+
+### Features
+
+* **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))

--- a/packages/styles/package-lock.json
+++ b/packages/styles/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-styles",
-  "version": "0.0.0",
+  "version": "0.0.1-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-styles",
-  "version": "0.0.0",
+  "version": "0.0.1-alpha.0",
   "description": "Styles for czedi-kit components",
   "keywords": [
     "design system",
@@ -31,7 +31,7 @@
     "url": "https://github.com/chanzuckerberg/lp-design-system/issues"
   },
   "dependencies": {
-    "@chanzuckerberg/czedi-kit-tokens": "^0.0.0"
+    "@chanzuckerberg/czedi-kit-tokens": "^0.0.1-alpha.0"
   },
   "devDependencies": {
     "@csstools/postcss-sass": "^4.0.0",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -10,7 +10,7 @@
   ],
   "author": "Devin Witherspoon <dcwither@gmail.com>",
   "homepage": "https://github.com/chanzuckerberg/lp-design-system/tree/master/packages/czedi-kit-styles#readme",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "restricted",

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.0.1-alpha.0 (2020-06-11)
+
+
+### Bug Fixes
+
+* **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
+
+
+### Features
+
+* **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))

--- a/packages/tokens/package-lock.json
+++ b/packages/tokens/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-tokens",
-  "version": "0.0.0",
+  "version": "0.0.1-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-tokens",
-  "version": "0.0.0",
+  "version": "0.0.1-alpha.0",
   "description": "Design tokens czedi-kit packages",
   "keywords": [
     "design",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -8,11 +8,11 @@
   ],
   "author": "Devin Witherspoon <dcwither@gmail.com>",
   "homepage": "https://github.com/chanzuckerberg/lp-design-system/tree/master/packages/czedi-kit-tokens#readme",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "main": "src/index.js",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
-    "access": "restricted",
+    "access": "public",
     "directory": "dist/"
   },
   "repository": {


### PR DESCRIPTION
### Summary:
Initial alpha publish, as well as changelog for this publish. This also revealed that publishing to github registry requires that an access token is provided which is frustrating.

### Test Plan:
`lerna publish`
https://github.com/chanzuckerberg/lp-design-system/packages