### PR TITLE
Dcwither/v0.0.1 alpha.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ typings/
 # Optional npm cache directory
 .npm
 
+# NPM publishing access
+.npmrc
+
 # Optional eslint cache
 .eslintcache
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.1-alpha.1 (2020-07-17)
+
+
+### Bug Fixes
+
+* **pre-push:** fix pre-push tests to use lerna and stream output ([0b59873](https://github.com/chanzuckerberg/lp-design-system/commit/0b5987303ad1399c5c70ce043ba9dae65a1d73d6))
+* **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
+
+
+### Features
+
+* **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
+* **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))
+
+
+
+
+
 ## 0.0.1-alpha.0 (2020-06-11)
 
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ This isn't something we'll be doing every day
 
 ```bash
 npx lerna create '@chanzuckerberg/czedi-kit-<package-name>' \
-  --registry="https://npm.pkg.github.com/" \
   --access="restricted" \
   --license="UNLICENSED"
 ```

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.1-alpha.0"
+  "version": "0.0.1-alpha.1"
 }

--- a/package.json
+++ b/package.json
@@ -74,12 +74,10 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "prettier --write",
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ],
     "*.scss": [
-      "stylelint --fix",
-      "git add"
+      "stylelint --fix"
     ]
   }
 }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.1-alpha.1 (2020-07-17)
+
+
+### Features
+
+* **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
+
+
+
+
+
 ## 0.0.1-alpha.0 (2020-06-11)
 
 

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-components",
-  "version": "0.0.1-alpha.0",
+  "version": "0.0.1-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,9 +11,9 @@
   "license": "MIT",
   "main": "dist/index.js",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
     "access": "restricted",
-    "directory": "dist/"
+    "directory": "dist/",
+    "registry": "https://registry.npmjs.org/"
   },
   "repository": {
     "type": "git",
@@ -26,6 +26,7 @@
     "build:watch": "npm run build:ts -- --watch",
     "build:storybook": "build-storybook",
     "deploy:docs": "storybook-to-ghpages --ci",
+    "prepack": "npm run build && cp ./package.json dist/",
     "snapshot": "percy-storybook --widths=320,1280",
     "storybook": "start-storybook -p 6006",
     "start": "npm run storybook",
@@ -71,5 +72,6 @@
     "ts-jest": "^24.1.0",
     "ts-loader": "^6.2.0",
     "typescript": "^3.6.4"
-  }
+  },
+  "gitHead": "901f254d36753d6d754dcbc996399a9db536fc13"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-components",
-  "version": "0.0.1-alpha.0",
+  "version": "0.0.1-alpha.1",
   "description": "React components for czedi-kit",
   "keywords": [
     "design system",
@@ -40,8 +40,8 @@
     "react": ">= 16.8.0"
   },
   "dependencies": {
-    "@chanzuckerberg/czedi-kit-styles": "^0.0.1-alpha.0",
-    "@chanzuckerberg/czedi-kit-tokens": "^0.0.1-alpha.0",
+    "@chanzuckerberg/czedi-kit-styles": "^0.0.1-alpha.1",
+    "@chanzuckerberg/czedi-kit-tokens": "^0.0.1-alpha.1",
     "classnames": "^2.2.6"
   },
   "devDependencies": {

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.1-alpha.1 (2020-07-17)
+
+
+### Features
+
+* **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
+
+
+
+
+
 ## 0.0.1-alpha.0 (2020-06-11)
 
 

--- a/packages/styles/package-lock.json
+++ b/packages/styles/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-styles",
-  "version": "0.0.1-alpha.0",
+  "version": "0.0.1-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-styles",
-  "version": "0.0.1-alpha.0",
+  "version": "0.0.1-alpha.1",
   "description": "Styles for czedi-kit components",
   "keywords": [
     "design system",
@@ -32,7 +32,7 @@
     "url": "https://github.com/chanzuckerberg/lp-design-system/issues"
   },
   "dependencies": {
-    "@chanzuckerberg/czedi-kit-tokens": "^0.0.1-alpha.0"
+    "@chanzuckerberg/czedi-kit-tokens": "^0.0.1-alpha.1"
   },
   "devDependencies": {
     "@csstools/postcss-sass": "^4.0.0",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -12,9 +12,9 @@
   "homepage": "https://github.com/chanzuckerberg/lp-design-system/tree/master/packages/czedi-kit-styles#readme",
   "license": "MIT",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
     "access": "restricted",
-    "directory": "dist/"
+    "directory": "dist/",
+    "registry": "https://registry.npmjs.org/"
   },
   "repository": {
     "type": "git",
@@ -25,6 +25,7 @@
     "build:clean": "rm -rf dist/",
     "build:css": "postcss src/*.scss src/*/[a-z\\-]*.scss --no-map --ext=css --dir=dist/ --base=src/",
     "build:watch": "npm run build:css -- --watch --verbose",
+    "prepack": "npm run build && cp ./package.json dist/",
     "start": "npm run build:watch"
   },
   "bugs": {
@@ -43,5 +44,6 @@
     "postcss-rtl": "^1.5.0",
     "postcss-scss": "^2.0.0",
     "tailwindcss": "^1.2.0"
-  }
+  },
+  "gitHead": "901f254d36753d6d754dcbc996399a9db536fc13"
 }

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.1-alpha.1 (2020-07-17)
+
+
+### Bug Fixes
+
+* **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
+
+
+### Features
+
+* **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))
+
+
+
+
+
 ## 0.0.1-alpha.0 (2020-06-11)
 
 

--- a/packages/tokens/package-lock.json
+++ b/packages/tokens/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-tokens",
-  "version": "0.0.1-alpha.0",
+  "version": "0.0.1-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-tokens",
-  "version": "0.0.1-alpha.0",
+  "version": "0.0.1-alpha.1",
   "description": "Design tokens czedi-kit packages",
   "keywords": [
     "design",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -11,21 +11,23 @@
   "license": "MIT",
   "main": "src/index.js",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
     "access": "public",
-    "directory": "dist/"
+    "directory": "dist/",
+    "registry": "https://registry.npmjs.org/"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chanzuckerberg/lp-design-system.git"
   },
   "scripts": {
-    "build": "style-dictionary build"
+    "build": "style-dictionary build",
+    "prepack": "npm run build && cp ./package.json dist/"
   },
   "bugs": {
     "url": "https://github.com/chanzuckerberg/lp-design-system/issues"
   },
   "devDependencies": {
     "style-dictionary": "^2.8.2"
-  }
+  },
+  "gitHead": "901f254d36753d6d754dcbc996399a9db536fc13"
 }


### PR DESCRIPTION
### Summary:
Update versions for published [v0.0.1-alpha.1](https://www.npmjs.com/package/@chanzuckerberg/czedi-kit-tokens/v/0.0.1-alpha.1)

### Test Plan:
