### PR TITLE
feat(colors): add eds colors to tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:scripts:fix": "npm run lint:scripts -- --fix",
     "postinstall": "lerna bootstrap",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx}\"",
-    "start": "lerna run build && lerna run start --parallel"
+    "start": "lerna run build --ignore=@chanzuckerberg/czedi-kit-components && lerna run start --parallel"
   },
   "size-limit": [
     {

--- a/packages/components/src/tokens.stories.mdx
+++ b/packages/components/src/tokens.stories.mdx
@@ -9,10 +9,46 @@ import "./tokens.stories.scss";
 
 # Design Tokens
 
-## Legacy Colors
+## EDS Colors
 
-export const mapLegacyColorToTokenArray = color => {
-  return Object.keys(tokens.legacy.color[color]).map(shade => ({
+export const mapEDSColorToTokenArray = (color) => {
+  return Object.keys(tokens.eds.color[color])
+    .sort((shade1, shade2) => shade1.localeCompare(shade2))
+    .map((shade) => ({
+      name: `$eds-color-${color}-${shade}`,
+      value: tokens.eds.color[color][shade],
+    }));
+};
+
+<TokenTable
+  tokens={[
+    // Neutral Colors In Order
+    {
+      name: "$eds-color-white",
+      value: tokens.eds.color.white,
+    },
+    ...mapEDSColorToTokenArray("neutral"),
+    {
+      name: "$eds-color-black",
+      value: tokens.eds.color.black,
+    },
+    // Remaining Colors
+    ...["alert", "warning", "success", "info", "brand", "highlight"]
+      .map(mapEDSColorToTokenArray)
+      .flat(),
+  ]}
+  renderExample={(name, value) => (
+    <div
+      className="color-token-example-block"
+      style={{ backgroundColor: value }}
+    />
+  )}
+/>
+
+## Legacy (Claro) Colors
+
+export const mapLegacyColorToTokenArray = (color) => {
+  return Object.keys(tokens.legacy.color[color]).map((shade) => ({
     name: `$legacy-color-${color}-${shade}`,
     value: tokens.legacy.color[color][shade],
   }));

--- a/packages/tokens/package-lock.json
+++ b/packages/tokens/package-lock.json
@@ -73,6 +73,15 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "exec-sh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+      "dev": true,
+      "requires": {
+        "merge": "^1.2.0"
+      }
+    },
     "fs-extra": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
@@ -156,6 +165,12 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -237,6 +252,16 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "watch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
+      "integrity": "sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=",
+      "dev": true,
+      "requires": {
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -21,13 +21,15 @@
   },
   "scripts": {
     "build": "style-dictionary build",
-    "prepack": "npm run build && cp ./package.json dist/"
+    "prepack": "npm run build && cp ./package.json dist/",
+    "start": "watch 'npm run build' ./properties ./node_modules"
   },
   "bugs": {
     "url": "https://github.com/chanzuckerberg/lp-design-system/issues"
   },
   "devDependencies": {
-    "style-dictionary": "^2.8.2"
+    "style-dictionary": "^2.8.2",
+    "watch": "^1.0.2"
   },
   "gitHead": "8680dac1fa3c685e2a35f80d9ceb157f5f5343bd"
 }

--- a/packages/tokens/properties/color/base.json
+++ b/packages/tokens/properties/color/base.json
@@ -57,5 +57,73 @@
         "400": { "value": "#32417C" }
       }
     }
+  },
+  "eds": {
+    "color": {
+      "neutral": {
+        "00": { "value": "#F3F3F3" },
+        "10": { "value": "#E8E8E9" },
+        "20": { "value": "#CAD1D8" },
+        "30": { "value": "#838C95" },
+        "40": { "value": "#58636F" },
+        "50": { "value": "#3C444C" },
+        "60": { "value": "#21272D" }
+      },
+      "white": { "value": "#FFFFFF" },
+      "black": { "value": "{eds.color.neutral.60.value}" },
+      "alert": {
+        "00": { "value": "#FFEBF0" },
+        "10": { "value": "#FFCCD8" },
+        "20": { "value": "#FB90B0" },
+        "30": { "value": "#F76C96" },
+        "40": { "value": "#F1497C" },
+        "50": { "value": "#D41E52" },
+        "60": { "value": "#BD0044" }
+      },
+      "success": {
+        "00": { "value": "#ECFFF5" },
+        "10": { "value": "#B7E9CE" },
+        "20": { "value": "#8FDCB3" },
+        "30": { "value": "#59C88C" },
+        "40": { "value": "#00A96C" },
+        "50": { "value": "#008756" },
+        "60": { "value": "#007349" }
+      },
+      "info": {
+        "00": { "value": "#F1F9FF" },
+        "10": { "value": "#B0D5FF" },
+        "20": { "value": "#7FB9FD" },
+        "30": { "value": "#5CA7FF" },
+        "40": { "value": "#328EFB" },
+        "50": { "value": "#1977CD" },
+        "60": { "value": "#0563B8" }
+      },
+      "warning": {
+        "00": { "value": "#FFF1E9" },
+        "10": { "value": "#FFCBA6" },
+        "20": { "value": "#FFB077" },
+        "30": { "value": "#F6924A" },
+        "40": { "value": "#ED7200" },
+        "50": { "value": "#C64600" },
+        "60": { "value": "#AC3400" }
+      },
+      "brand": {
+        "00": { "value": "#F7F1FF" },
+        "10": { "value": "#C3C0FE" },
+        "20": { "value": "#A7A2FE" },
+        "30": { "value": "#928CFF" },
+        "40": { "value": "#766FFD" },
+        "50": { "value": "#574EFF" },
+        "60": { "value": "#433BDE" }
+      },
+      "highlight": {
+        "00": { "value": "#FF9FEC" },
+        "10": { "value": "#FFBEAA" },
+        "20": { "value": "#FCFF00" },
+        "30": { "value": "#9DFFA4" },
+        "40": { "value": "#00F1FF" },
+        "50": { "value": "#CFC9FF" }
+      }
+    }
   }
 }


### PR DESCRIPTION
### Summary:
Ad design system colors from https://www.figma.com/file/sKEhNrLEdexPeVVn58dkWx/SDL-(Summit-Design-Language)-Explorations?node-id=690%3A0. Uses the eds prefix for now, we can revisit later before a 1.0.0 launch.

### Test Plan:
Ran in storybook with `npm start` to confirm new colors are added.

TODO: use new colors with tailwind etc.