### PR TITLE
chore: add vscode workspace to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ typings/
 # next.js build output
 .next
 
+# VS Code workspace file
+*.code-workspace
+
 # dist folders
 dist/
 storybook-static/


### PR DESCRIPTION
### Summary:
as titled, I might have saved my vscode workspace in a bad spot and this seemed easier than moving it

### Test Plan:
n/a