### PR TITLE
Dcwither/styled css variables

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,11 @@
 name: Deploy Docs
 
-on: 
+on:
   push:
     branches:
       - master
 
 jobs:
-
   deploy_docs:
     runs-on: ubuntu-latest
 
@@ -23,7 +22,7 @@ jobs:
 
       - name: Install Dependencies ⬆️
         run: |
-          npm ci
+          npm ci --no-optional
           npx lerna bootstrap
 
       - name: Build Dist 🔧
@@ -33,4 +32,3 @@ jobs:
         run: npx lerna run deploy:docs
         env:
           GH_TOKEN: "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}"
-      

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install Dependencies ⬆️
         run: |
-          npm ci
+          npm ci --no-optional
           npx lerna bootstrap
 
       - name: Run CI Tests ✅
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install Dependencies ⬆️
         run: |
-          npm ci
+          npm ci --no-optional
           npx lerna bootstrap
 
       - name: Build Dist 🔧
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build Storybook 🔧
         run: npx lerna run build:storybook
-        
+
       - name: Percy Snapshots 📸
         run: npx lerna run snapshot
         env:
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install Dependencies ⬆️
         run: |
-          npm ci
+          npm ci --no-optional
           npx lerna bootstrap
 
       - name: Lint Commit Messages 👕

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -1,8 +1,10 @@
+import "@chanzuckerberg/czedi-kit-tokens/css/variables.css";
+
 import * as React from "react";
 
 import { DocsContainer, DocsPage } from "@storybook/addon-docs/blocks";
-import EDSGlobalStyles from "../src/styles/global";
 
+import EDSGlobalStyles from "../src/styles/global";
 import { addDecorator } from "@storybook/react";
 import { addParameters } from "@storybook/react";
 import { withA11y } from "@storybook/addon-a11y";

--- a/packages/components/src/playground/button.spec.tsx
+++ b/packages/components/src/playground/button.spec.tsx
@@ -8,20 +8,20 @@ describe("<Button />", () => {
     expect(container.firstChild).toMatchInlineSnapshot(`
       <div>
         <button
-          class="button__ButtonComponent-ak17f2-0 knVmlo"
+          class="button__ButtonComponent-ak17f2-0 cKlymw"
         >
           <p
-            class="typography__TypographyComponent-sc-8fjfkf-0 fBebuQ"
+            class="typography__TypographyComponent-sc-8fjfkf-0 earSjG"
             color="white"
           >
             Hello Button
           </p>
         </button>
         <button
-          class="button__ButtonComponent-ak17f2-0 jDwPyC"
+          class="button__ButtonComponent-ak17f2-0 dMLRAo"
         >
           <p
-            class="typography__TypographyComponent-sc-8fjfkf-0 fBebuQ"
+            class="typography__TypographyComponent-sc-8fjfkf-0 earSjG"
             color="white"
           >
             Secondary Button

--- a/packages/components/src/typography/typography.spec.tsx
+++ b/packages/components/src/typography/typography.spec.tsx
@@ -8,25 +8,25 @@ describe("<Typography />", () => {
     expect(container.firstChild).toMatchInlineSnapshot(`
       <div>
         <p
-          class="typography__TypographyComponent-sc-8fjfkf-0 dJNOnb"
+          class="typography__TypographyComponent-sc-8fjfkf-0 gwgBif"
           color="base"
         >
           Default body text
         </p>
         <p
-          class="typography__TypographyComponent-sc-8fjfkf-0 ewwRSX"
+          class="typography__TypographyComponent-sc-8fjfkf-0 uqpCF"
           color="brand"
         >
           Brand color text
         </p>
         <h1
-          class="typography__TypographyComponent-sc-8fjfkf-0 cLGrwY"
+          class="typography__TypographyComponent-sc-8fjfkf-0 gVQrMo"
           color="base"
         >
           Bold heading 1
         </h1>
         <h1
-          class="typography__TypographyComponent-sc-8fjfkf-0 hDERns"
+          class="typography__TypographyComponent-sc-8fjfkf-0 evuFon"
           color="base"
         >
           Heading 1 styled as Heading 4

--- a/packages/components/tailwind.config.js
+++ b/packages/components/tailwind.config.js
@@ -1,5 +1,4 @@
 const tokens = require("@chanzuckerberg/czedi-kit-tokens/json/variables-nested.json");
-
 module.exports = {
   theme: {
     colors: tokens.eds.color,
@@ -8,6 +7,7 @@ module.exports = {
     },
     fontSize: tokens.eds.size.font,
     lineHeight: tokens.eds.size["line-height"],
+    extend: {},
   },
   variants: {},
   plugins: [],

--- a/packages/components/tailwind.config.js
+++ b/packages/components/tailwind.config.js
@@ -1,4 +1,4 @@
-const tokens = require("@chanzuckerberg/czedi-kit-tokens/json/variables-nested.json");
+const tokens = require("@chanzuckerberg/czedi-kit-tokens/json/css-variables-nested.json");
 module.exports = {
   theme: {
     colors: tokens.eds.color,

--- a/packages/tokens/config.js
+++ b/packages/tokens/config.js
@@ -4,31 +4,35 @@ const EDSStyleDictionary = StyleDictionary.extend({
   platforms: {
     scss: {
       transforms: [...StyleDictionary.transformGroup.scss, "name/kebabCase"],
-      buildPath: "dist/scss/",
+      buildPath: "dist/",
       files: [
         {
-          destination: "_variables.scss",
+          destination: "scss/_variables.scss",
           format: "scss/map-deep",
         },
       ],
     },
     css: {
       transforms: [...StyleDictionary.transformGroup.css, "name/kebabCase"],
-      buildPath: "dist/css/",
+      buildPath: "dist/",
       files: [
         {
           format: "css/variables",
-          destination: "variables.css",
+          destination: "css/variables.css",
+        },
+        {
+          format: "json/nested-css-variables",
+          destination: "json/css-variables-nested.json",
         },
       ],
     },
     js: {
       transformGroup: "js",
-      buildPath: "dist/js/",
+      buildPath: "dist/",
       files: [
         {
           format: "javascript/es6",
-          destination: "colors.js",
+          destination: "js/colors.js",
           filter: {
             attributes: {
               type: "color",
@@ -39,15 +43,15 @@ const EDSStyleDictionary = StyleDictionary.extend({
     },
     json: {
       transformGroup: "js",
-      buildPath: "dist/json/",
+      buildPath: "dist/",
       files: [
         {
           format: "json/flat",
-          destination: "variables.json",
+          destination: "json/variables.json",
         },
         {
           format: "json/nested",
-          destination: "variables-nested.json",
+          destination: "json/variables-nested.json",
         },
       ],
     },
@@ -59,6 +63,31 @@ EDSStyleDictionary.registerTransform({
   type: "name",
   transformer: function ({ path }) {
     return path.join("-").toLowerCase();
+  },
+});
+
+// copied from https://github.com/amzn/style-dictionary/blob/v3.0.0-rc.1/lib/common/formats.js#L96
+function minifyDictionary(obj) {
+  if (typeof obj !== "object" || Array.isArray(obj)) {
+    return obj;
+  }
+
+  var toRet = {};
+
+  if (obj.value) {
+    return `var(--${obj.name})`;
+  } else {
+    for (var name in obj) {
+      toRet[name] = minifyDictionary(obj[name]);
+    }
+  }
+  return toRet;
+}
+
+EDSStyleDictionary.registerFormat({
+  name: "json/nested-css-variables",
+  formatter: function (dictionary) {
+    return JSON.stringify(minifyDictionary(dictionary.properties), null, 2);
   },
 });
 

--- a/packages/tokens/dist/css/variables.css
+++ b/packages/tokens/dist/css/variables.css
@@ -1,8 +1,3 @@
-/**
- * Do not edit directly
- * Generated on Tue, 15 Dec 2020 23:47:48 GMT
- */
-
 :root {
   --legacy-color-gray-50: #F8F9FC;
   --legacy-color-gray-100: #EBEBEC;

--- a/packages/tokens/dist/css/variables.css
+++ b/packages/tokens/dist/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 14 Dec 2020 20:56:45 GMT
+ * Generated on Tue, 15 Dec 2020 23:47:48 GMT
  */
 
 :root {

--- a/packages/tokens/dist/js/colors.js
+++ b/packages/tokens/dist/js/colors.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 14 Dec 2020 20:56:45 GMT
+ * Generated on Tue, 15 Dec 2020 23:47:48 GMT
  */
 
 export const LegacyColorGray50 = "#F8F9FC";

--- a/packages/tokens/dist/js/colors.js
+++ b/packages/tokens/dist/js/colors.js
@@ -1,8 +1,3 @@
-/**
- * Do not edit directly
- * Generated on Tue, 15 Dec 2020 23:47:48 GMT
- */
-
 export const LegacyColorGray50 = "#F8F9FC";
 export const LegacyColorGray100 = "#EBEBEC";
 export const LegacyColorGray200 = "#D8D8D9";

--- a/packages/tokens/dist/json/css-variables-nested.json
+++ b/packages/tokens/dist/json/css-variables-nested.json
@@ -1,0 +1,155 @@
+{
+  "legacy": {
+    "color": {
+      "gray": {
+        "50": "var(--legacy-color-gray-50)",
+        "100": "var(--legacy-color-gray-100)",
+        "200": "var(--legacy-color-gray-200)",
+        "300": "var(--legacy-color-gray-300)",
+        "400": "var(--legacy-color-gray-400)",
+        "500": "var(--legacy-color-gray-500)",
+        "600": "var(--legacy-color-gray-600)",
+        "700": "var(--legacy-color-gray-700)",
+        "800": "var(--legacy-color-gray-800)",
+        "900": "var(--legacy-color-gray-900)",
+        "1000": "var(--legacy-color-gray-1000)"
+      },
+      "black": "var(--legacy-color-black)",
+      "white": "var(--legacy-color-white)",
+      "red": {
+        "100": "var(--legacy-color-red-100)",
+        "150": "var(--legacy-color-red-150)",
+        "200": "var(--legacy-color-red-200)",
+        "300": "var(--legacy-color-red-300)",
+        "350": "var(--legacy-color-red-350)",
+        "400": "var(--legacy-color-red-400)"
+      },
+      "green": {
+        "100": "var(--legacy-color-green-100)",
+        "150": "var(--legacy-color-green-150)",
+        "200": "var(--legacy-color-green-200)",
+        "300": "var(--legacy-color-green-300)",
+        "350": "var(--legacy-color-green-350)",
+        "400": "var(--legacy-color-green-400)"
+      },
+      "blue": {
+        "100": "var(--legacy-color-blue-100)",
+        "150": "var(--legacy-color-blue-150)",
+        "200": "var(--legacy-color-blue-200)",
+        "300": "var(--legacy-color-blue-300)",
+        "350": "var(--legacy-color-blue-350)",
+        "400": "var(--legacy-color-blue-400)"
+      },
+      "yellow": {
+        "100": "var(--legacy-color-yellow-100)",
+        "150": "var(--legacy-color-yellow-150)",
+        "200": "var(--legacy-color-yellow-200)",
+        "300": "var(--legacy-color-yellow-300)",
+        "350": "var(--legacy-color-yellow-350)",
+        "400": "var(--legacy-color-yellow-400)"
+      },
+      "purple": {
+        "100": "var(--legacy-color-purple-100)",
+        "150": "var(--legacy-color-purple-150)",
+        "200": "var(--legacy-color-purple-200)",
+        "300": "var(--legacy-color-purple-300)",
+        "350": "var(--legacy-color-purple-350)",
+        "400": "var(--legacy-color-purple-400)"
+      }
+    }
+  },
+  "eds": {
+    "color": {
+      "neutral": {
+        "100": "var(--eds-color-neutral-100)",
+        "200": "var(--eds-color-neutral-200)",
+        "300": "var(--eds-color-neutral-300)",
+        "400": "var(--eds-color-neutral-400)",
+        "500": "var(--eds-color-neutral-500)",
+        "600": "var(--eds-color-neutral-600)",
+        "700": "var(--eds-color-neutral-700)"
+      },
+      "white": "var(--eds-color-white)",
+      "black": "var(--eds-color-black)",
+      "alert": {
+        "100": "var(--eds-color-alert-100)",
+        "200": "var(--eds-color-alert-200)",
+        "300": "var(--eds-color-alert-300)",
+        "400": "var(--eds-color-alert-400)",
+        "500": "var(--eds-color-alert-500)",
+        "600": "var(--eds-color-alert-600)",
+        "700": "var(--eds-color-alert-700)"
+      },
+      "success": {
+        "100": "var(--eds-color-success-100)",
+        "200": "var(--eds-color-success-200)",
+        "300": "var(--eds-color-success-300)",
+        "400": "var(--eds-color-success-400)",
+        "500": "var(--eds-color-success-500)",
+        "600": "var(--eds-color-success-600)",
+        "700": "var(--eds-color-success-700)"
+      },
+      "info": {
+        "100": "var(--eds-color-info-100)",
+        "200": "var(--eds-color-info-200)",
+        "300": "var(--eds-color-info-300)",
+        "400": "var(--eds-color-info-400)",
+        "500": "var(--eds-color-info-500)",
+        "600": "var(--eds-color-info-600)",
+        "700": "var(--eds-color-info-700)"
+      },
+      "warning": {
+        "100": "var(--eds-color-warning-100)",
+        "200": "var(--eds-color-warning-200)",
+        "300": "var(--eds-color-warning-300)",
+        "400": "var(--eds-color-warning-400)",
+        "500": "var(--eds-color-warning-500)",
+        "600": "var(--eds-color-warning-600)",
+        "700": "var(--eds-color-warning-700)"
+      },
+      "brand": {
+        "100": "var(--eds-color-brand-100)",
+        "200": "var(--eds-color-brand-200)",
+        "300": "var(--eds-color-brand-300)",
+        "400": "var(--eds-color-brand-400)",
+        "500": "var(--eds-color-brand-500)",
+        "600": "var(--eds-color-brand-600)",
+        "700": "var(--eds-color-brand-700)"
+      },
+      "highlight": {
+        "100": "var(--eds-color-highlight-100)",
+        "200": "var(--eds-color-highlight-200)",
+        "300": "var(--eds-color-highlight-300)",
+        "400": "var(--eds-color-highlight-400)",
+        "500": "var(--eds-color-highlight-500)",
+        "600": "var(--eds-color-highlight-600)"
+      },
+      "font": {
+        "base": "var(--eds-color-font-base)",
+        "link": "var(--eds-color-font-link)"
+      }
+    },
+    "size": {
+      "font": {
+        "h1": "var(--eds-size-font-h1)",
+        "h2": "var(--eds-size-font-h2)",
+        "h3": "var(--eds-size-font-h3)",
+        "h4": "var(--eds-size-font-h4)",
+        "h5": "var(--eds-size-font-h5)",
+        "base": "var(--eds-size-font-base)",
+        "body": "var(--eds-size-font-body)",
+        "sm": "var(--eds-size-font-sm)",
+        "xs": "var(--eds-size-font-xs)"
+      },
+      "line-height": {
+        "h1": "var(--eds-size-line-height-h1)",
+        "h2": "var(--eds-size-line-height-h2)",
+        "h3": "var(--eds-size-line-height-h3)",
+        "h4": "var(--eds-size-line-height-h4)",
+        "body": "var(--eds-size-line-height-body)",
+        "sm": "var(--eds-size-line-height-sm)",
+        "xs": "var(--eds-size-line-height-xs)"
+      }
+    }
+  }
+}

--- a/packages/tokens/dist/scss/_variables.scss
+++ b/packages/tokens/dist/scss/_variables.scss
@@ -1,7 +1,7 @@
 
 /*
   Do not edit directly
-  Generated on Mon, 14 Dec 2020 20:56:45 GMT
+  Generated on Tue, 15 Dec 2020 23:47:48 GMT
 */
 
 $legacy-color-gray-50: #F8F9FC !default;

--- a/packages/tokens/dist/scss/_variables.scss
+++ b/packages/tokens/dist/scss/_variables.scss
@@ -1,8 +1,4 @@
 
-/*
-  Do not edit directly
-  Generated on Tue, 15 Dec 2020 23:47:48 GMT
-*/
 
 $legacy-color-gray-50: #F8F9FC !default;
 $legacy-color-gray-100: #EBEBEC !default;

--- a/packages/tokens/package-lock.json
+++ b/packages/tokens/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "dependencies": {
     "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "^2.0.1"
       }
     },
     "balanced-match": {
@@ -30,47 +30,40 @@
       }
     },
     "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       }
     },
     "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "exec-sh": {
@@ -83,12 +76,12 @@
       }
     },
     "fs-extra": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
+        "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
       }
@@ -120,9 +113,9 @@
       "dev": true
     },
     "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
     "inflight": {
@@ -160,9 +153,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "merge": {
@@ -202,49 +195,49 @@
       "dev": true
     },
     "resolve-cwd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "^5.0.0"
       }
     },
     "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
     "style-dictionary": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-2.10.0.tgz",
-      "integrity": "sha512-H4NpAKExmQdSMLNm9jVY8Kv+qfliFOgpxl07mqL+NyMMRs7HjR8IDvNJfxYqiVm0BhSpwFAp/hkUlD+8i7+P8w==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-2.10.2.tgz",
+      "integrity": "sha512-1GgtokijUl46tFXFGMmGPioO9xMzTBcCRfufYUZ61OxYRUEDT93M7Y9YxD+udgrHN2pYRrS/CiToM4jARBTccQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
-        "commander": "^2.9.0",
-        "fs-extra": "^6.0.1",
-        "glob": "^7.1.1",
-        "json5": "^2.1.0",
+        "chalk": "^4.0.0",
+        "commander": "^5.1.0",
+        "fs-extra": "^8.1.0",
+        "glob": "^7.1.6",
+        "json5": "^2.1.3",
         "lodash": "^4.17.15",
-        "resolve-cwd": "^2.0.0",
+        "resolve-cwd": "^3.0.0",
         "tinycolor2": "^1.4.1"
       }
     },
     "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       }
     },
     "tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
       "dev": true
     },
     "universalify": {

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/chanzuckerberg/lp-design-system.git"
   },
   "scripts": {
-    "build": "style-dictionary build",
+    "build": "style-dictionary build --config=./style-dictionary.config.js",
     "prepack": "npm run build && cp ./package.json dist/",
     "start": "watch 'npm run build' ./properties ./node_modules"
   },

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/chanzuckerberg/lp-design-system/issues"
   },
   "devDependencies": {
-    "style-dictionary": "^2.8.2",
+    "style-dictionary": "^2.10.2",
     "watch": "^1.0.2"
   },
   "gitHead": "8680dac1fa3c685e2a35f80d9ceb157f5f5343bd"

--- a/packages/tokens/style-dictionary.config.js
+++ b/packages/tokens/style-dictionary.config.js
@@ -7,8 +7,11 @@ const EDSStyleDictionary = StyleDictionary.extend({
       buildPath: "dist/",
       files: [
         {
-          destination: "scss/_variables.scss",
           format: "scss/map-deep",
+          destination: "scss/_variables.scss",
+          options: {
+            showFileHeader: false,
+          },
         },
       ],
     },
@@ -19,10 +22,16 @@ const EDSStyleDictionary = StyleDictionary.extend({
         {
           format: "css/variables",
           destination: "css/variables.css",
+          options: {
+            showFileHeader: false,
+          },
         },
         {
           format: "json/nested-css-variables",
           destination: "json/css-variables-nested.json",
+          options: {
+            showFileHeader: false,
+          },
         },
       ],
     },
@@ -33,6 +42,9 @@ const EDSStyleDictionary = StyleDictionary.extend({
         {
           format: "javascript/es6",
           destination: "js/colors.js",
+          options: {
+            showFileHeader: false,
+          },
           filter: {
             attributes: {
               type: "color",
@@ -48,10 +60,16 @@ const EDSStyleDictionary = StyleDictionary.extend({
         {
           format: "json/flat",
           destination: "json/variables.json",
+          options: {
+            showFileHeader: false,
+          },
         },
         {
           format: "json/nested",
           destination: "json/variables-nested.json",
+          options: {
+            showFileHeader: false,
+          },
         },
       ],
     },
@@ -67,7 +85,7 @@ EDSStyleDictionary.registerTransform({
 });
 
 // copied from https://github.com/amzn/style-dictionary/blob/v3.0.0-rc.1/lib/common/formats.js#L96
-function minifyDictionary(obj) {
+function minifyCSSVarDictionary(obj) {
   if (typeof obj !== "object" || Array.isArray(obj)) {
     return obj;
   }
@@ -78,7 +96,7 @@ function minifyDictionary(obj) {
     return `var(--${obj.name})`;
   } else {
     for (var name in obj) {
-      toRet[name] = minifyDictionary(obj[name]);
+      toRet[name] = minifyCSSVarDictionary(obj[name]);
     }
   }
   return toRet;
@@ -87,7 +105,11 @@ function minifyDictionary(obj) {
 EDSStyleDictionary.registerFormat({
   name: "json/nested-css-variables",
   formatter: function (dictionary) {
-    return JSON.stringify(minifyDictionary(dictionary.properties), null, 2);
+    return JSON.stringify(
+      minifyCSSVarDictionary(dictionary.properties),
+      null,
+      2
+    );
   },
 });
 


### PR DESCRIPTION
### Summary:
Create a new format for style dictionary config, this allows us to pull in css variables into tailwind for easy theming and to get rid of the pesky `--tw-bg-opacity` and `--tw-text-opacity`

Some bonus tasks done in this PR:
- CI uses `npm ci --no-optional` to resolve node-gyp issues
- No more tokens file headers, this prevents unnecessary compilation annoyance
- rename `config.js` to `style-dictionary.config.js` and reference it properly for more happiness

### Test Plan:
Check the tokens build, `npm start`, CI
