### PR TITLE
Revert "Update package-lock"

### DIFF
--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -4918,6 +4918,11 @@
       "integrity": "sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==",
       "dev": true
     },
+    "@chanzuckerberg/czedi-kit-tokens": {
+      "version": "0.0.1-alpha.5",
+      "resolved": "https://registry.npmjs.org/@chanzuckerberg/czedi-kit-tokens/-/czedi-kit-tokens-0.0.1-alpha.5.tgz",
+      "integrity": "sha512-jwj4VeiXPxHn5ozigXncvs/+tVKXHeS35c4vfuRN0adwQJDtebgSbjkZQbAUBG7iAtoRqAivPLUNIgpCv5ho4g=="
+    },
     "@cnakazawa/watch": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",


### PR DESCRIPTION
Reverts chanzuckerberg/lp-design-system#243

Actually, now I think this is supposed to be present. But it's weird because:

- Sometimes running `npm install` from the top-level removes it...
- Sometimes running `npx lerna bootstrap` adds it back...

But I think your initial thought was right, @anniehu4 - since it's in the package.json for components/, it should be in the package-lock. Probably.

@dcwither do you have any insights as to what the heck is going on here?