### PR TITLE
test(snapshots): remove classes from snapshots

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,7 +35,7 @@
       "extends": ["plugin:@typescript-eslint/recommended"]
     },
     {
-      "files": ["*.spec.ts", "*.spec.tsx"],
+      "files": ["*.spec.ts", "*.spec.tsx", "**/test/**"],
       "plugins": ["jest"],
       "extends": ["plugin:jest/recommended"],
       "env": {

--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -3,7 +3,7 @@
 
 module.exports = {
   clearMocks: true,
-  setupFilesAfterEnv: ["jest-axe/extend-expect"],
+  setupFilesAfterEnv: ["jest-axe/extend-expect", "./test/jest.setup.ts"],
   coverageDirectory: "coverage",
   transform: {
     "^.+\\.tsx?$": "babel-jest",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -4918,11 +4918,6 @@
       "integrity": "sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==",
       "dev": true
     },
-    "@chanzuckerberg/czedi-kit-tokens": {
-      "version": "0.0.1-alpha.5",
-      "resolved": "https://registry.npmjs.org/@chanzuckerberg/czedi-kit-tokens/-/czedi-kit-tokens-0.0.1-alpha.5.tgz",
-      "integrity": "sha512-jwj4VeiXPxHn5ozigXncvs/+tVKXHeS35c4vfuRN0adwQJDtebgSbjkZQbAUBG7iAtoRqAivPLUNIgpCv5ho4g=="
-    },
     "@cnakazawa/watch": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -12235,6 +12230,26 @@
         "randomfill": "^1.0.3"
       }
     },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
@@ -17096,6 +17111,15 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
+      }
+    },
+    "jest-styled-components": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-7.0.3.tgz",
+      "integrity": "sha512-jj9sWyshehUnB0P9WFUaq9Bkh6RKYO8aD8lf3gUrXRwg/MRddTFk7U9D9pC4IAI3v9fbz4vmrMxwaecTpG8NKA==",
+      "dev": true,
+      "requires": {
+        "css": "^2.2.4"
       }
     },
     "jest-util": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -74,6 +74,7 @@
     "babel-plugin-module-resolver": "^4.0.0",
     "jest": "^24.9.0",
     "jest-axe": "^3.5.0",
+    "jest-styled-components": "^7.0.3",
     "postcss": "^8.2.1",
     "react": "^16.14.0",
     "react-docgen-typescript-loader": "^3.7.2",

--- a/packages/components/src/playground/button.spec.tsx
+++ b/packages/components/src/playground/button.spec.tsx
@@ -7,21 +7,15 @@ describe("<Button />", () => {
     const { container } = render(variants());
     expect(container.firstChild).toMatchInlineSnapshot(`
       <div>
-        <button
-          class="button__ButtonComponent-ak17f2-0 cKlymw"
-        >
+        <button>
           <p
-            class="typography__TypographyComponent-sc-8fjfkf-0 earSjG"
             color="white"
           >
             Hello Button
           </p>
         </button>
-        <button
-          class="button__ButtonComponent-ak17f2-0 dMLRAo"
-        >
+        <button>
           <p
-            class="typography__TypographyComponent-sc-8fjfkf-0 earSjG"
             color="white"
           >
             Secondary Button

--- a/packages/components/src/typography/typography.spec.tsx
+++ b/packages/components/src/typography/typography.spec.tsx
@@ -8,25 +8,21 @@ describe("<Typography />", () => {
     expect(container.firstChild).toMatchInlineSnapshot(`
       <div>
         <p
-          class="typography__TypographyComponent-sc-8fjfkf-0 gwgBif"
           color="base"
         >
           Default body text
         </p>
         <p
-          class="typography__TypographyComponent-sc-8fjfkf-0 uqpCF"
           color="brand"
         >
           Brand color text
         </p>
         <h1
-          class="typography__TypographyComponent-sc-8fjfkf-0 gVQrMo"
           color="base"
         >
           Bold heading 1
         </h1>
         <h1
-          class="typography__TypographyComponent-sc-8fjfkf-0 evuFon"
           color="base"
         >
           Heading 1 styled as Heading 4

--- a/packages/components/test/jest.setup.ts
+++ b/packages/components/test/jest.setup.ts
@@ -1,0 +1,1 @@
+import "./removeClassSnapshotSerializer";

--- a/packages/components/test/removeClassSnapshotSerializer.ts
+++ b/packages/components/test/removeClassSnapshotSerializer.ts
@@ -1,0 +1,58 @@
+/**
+ * Borrowed parts from jest-styled-components with a customized print function.
+ * Instead of injecting styles and modifying classes, this custom
+ * serializer will remove them completely.
+ */
+import { styleSheetSerializer } from "jest-styled-components";
+
+const KEY = "__jest-styled-components__";
+
+type NodeType = {
+  [KEY]: boolean;
+  children: NodeType[];
+};
+
+const markNodes = (nodes: NodeType[]): void =>
+  nodes.forEach((node) => (node[KEY] = true));
+
+const getNodes = (node: NodeType, nodes: NodeType[] = []): NodeType[] => {
+  if (typeof node === "object") {
+    nodes.push(node);
+  }
+
+  if (node.children) {
+    Array.from(node.children).forEach((child) => getNodes(child, nodes));
+  }
+
+  return nodes;
+};
+
+/**
+ * Remove all class attributes from the specified code
+ */
+const removeClassNames = (code: string): string => {
+  return code.replace(/\n\s*class=".+"( )*/g, "");
+};
+
+const collapseEmptyElements = (code: string): string => {
+  return code.replace(/<(\w+)\s*>/g, (match, element) => {
+    return `<${element}>`;
+  });
+};
+
+expect.addSnapshotSerializer({
+  test: styleSheetSerializer.test,
+  print(value, serialize) {
+    /**
+     * Mark the nodes we will serialize. The `styleSheetSerializer.test`
+     * will skip anything we have already processed.
+     */
+    const nodes = getNodes(value as NodeType);
+    markNodes(nodes);
+
+    const code = serialize(value);
+    const result = collapseEmptyElements(removeClassNames(code));
+
+    return result;
+  },
+});


### PR DESCRIPTION
### Summary:
Pulled `https://github.com/chanzuckerberg/along/blob/main/client/src/test/removeStylesJestSerializer.ts` from along - we should consider moving this into https://github.com/chanzuckerberg/frontend-libs

### Test Plan:
`npm test`