### PR TITLE
fix(typography): render Arimo in storybook properly

### DIFF
--- a/packages/components/src/styles/global.js
+++ b/packages/components/src/styles/global.js
@@ -1,13 +1,17 @@
 import { GlobalStyles } from "twin.macro";
 import React from "react";
+import arimoBoldWoff from "./fonts/arimo-bold.woff";
+import arimoBoldWoff2 from "./fonts/arimo-bold.woff2";
+import arimoRegularWoff from "./fonts/arimo-regular.woff";
+import arimoRegularWoff2 from "./fonts/arimo-regular.woff2";
 import { createGlobalStyle } from "styled-components";
 
 const GlobalFonts = createGlobalStyle`
   @font-face {
     font-family: 'Arimo';
     src:
-      url(fonts/arimo-regular.woff2) format('woff2'),
-      url(fonts/arimo-regular.woff) format('woff');
+      url(${arimoRegularWoff2}) format('woff2'),
+      url(${arimoRegularWoff}) format('woff');
     font-weight: 400;
     font-style: normal;
   }
@@ -15,8 +19,8 @@ const GlobalFonts = createGlobalStyle`
   @font-face {
     font-family: 'Arimo';
     src:
-      url(fonts/arimo-bold.woff2) format('woff2'),
-      url(fonts/arimo-bold.woff) format('woff');
+      url(${arimoBoldWoff2}) format('woff2'),
+      url(${arimoBoldWoff}) format('woff');
     font-weight: 700;
     font-style: normal;
   }

--- a/packages/components/src/typography/typography.stories.tsx
+++ b/packages/components/src/typography/typography.stories.tsx
@@ -10,50 +10,67 @@ export default {
 export const SizeRamp = (): JSX.Element => (
   <div>
     <Typography bold size="h1">
-      Heading 1 48/64 bold
+      H1 Heading 1
     </Typography>
-    <Typography size="h1">Heading 1 48/64</Typography>
+    <br />
+    <Typography size="h1">H1 Heading 1 48/64</Typography>
+    <br />
     <br />
     <Typography bold size="h2">
-      Heading 2 40/56 bold
+      H2 Heading 2
     </Typography>
-    <Typography size="h2">Heading 2 40/56</Typography>
+    <br />
+    <Typography size="h2">H2 Heading 2 40/56</Typography>
+    <br />
     <br />
     <Typography bold size="h3">
-      Heading 3 32/40 bold
+      H3 Heading 3
     </Typography>
-    <Typography size="h3">Heading 3 32/40</Typography>
+    <br />
+    <Typography size="h3">H3 Heading 3 32/40</Typography>
+    <br />
     <br />
     <Typography bold size="h4">
-      Section Head 24/32
+      H4 Section Head
     </Typography>
-    <Typography size="h4">Page Title 24/32</Typography>
+    <br />
+    <Typography size="h4">H4 Page Title 24/32</Typography>
+    <br />
     <br />
     <Typography bold size="h5">
-      Section Sub Head 18/24
+      H5 Section Sub Head 18/24
     </Typography>
-    <Typography size="h5">Heading 5 18/24</Typography>
+    <br />
+    <Typography size="h5">H5 Heading 5 18/24</Typography>
+    <br />
     <br />
     <Typography bold size="body">
-      Paragraph header 16/24
+      Body paragraph header 16/24
     </Typography>
-    <Typography size="body">Paragraph text 16/24</Typography>
+    <br />
+    <Typography size="body">Body paragraph 16/24</Typography>
+    <br />
     <br />
     <Typography bold size="sm">
-      Small body text 14/20 bold
+      Body small text
     </Typography>
-    <Typography size="sm">Small body text 14/20</Typography>
+    <br />
+    <Typography size="sm">Body small 14/20</Typography>
+    <br />
     <br />
     <Typography bold size="xs">
-      Xsmall body text 12/16 bold
+      Body Xsmall text
     </Typography>
+    <br />
     <Typography size="xs">Year timeline, Year list 12/16</Typography>
     <br />
+    <br />
     <Typography bold size="button">
-      Button text 14/24
+      Button Text 14/24
     </Typography>
     <br />
     <Typography size="caption">Caption 12/20</Typography>
+    <br />
     <Typography size="overline">Overline 12/20</Typography>
   </div>
 );


### PR DESCRIPTION
### Summary:
https://app.clubhouse.io/connections/story/33653/ds-typography-confirm-with-design-through-percy

Sean pointed out that the Storybook fonts didn't actually look like Arimo -- turns out I wasn't loading the font files properly :')

### Test Plan:
Confirm storybook type:
<img width="250" alt="Screen Shot 2020-12-21 at 6 48 07 PM" src="https://user-images.githubusercontent.com/15840841/102832735-4165c280-43bd-11eb-9546-12bc3ff3a73b.png">

Matches Figma:
<img width="175" alt="Screen Shot 2020-12-21 at 6 50 00 PM" src="https://user-images.githubusercontent.com/15840841/102832764-55112900-43bd-11eb-9de6-79c830813235.png">

Especially look at the number 1, because that was clearly off before. Percy changes are expected