### PR TITLE
chore(release): publish v0.0.1-alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,75 +3,61 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.0.1-alpha.5](https://github.com/chanzuckerberg/lp-design-system/compare/v0.0.1-alpha.4...v0.0.1-alpha.5) (2020-10-19)
-
+## [0.0.1-alpha.6](https://github.com/chanzuckerberg/lp-design-system/compare/v0.0.1-alpha.5...v0.0.1-alpha.6) (2021-01-20)
 
 ### Features
 
-* **tokens:** replace eds token numbers ([59b3552](https://github.com/chanzuckerberg/lp-design-system/commit/59b355274973098315ba0bd531a760c2a0d9499e))
+- **typography:** add Typography component ([36f5d5c](https://github.com/chanzuckerberg/lp-design-system/commit/36f5d5c9e87e3515f69391426157361c05d523dd))
+- **typography:** add legacy and eds font tokens ([ddbaf64](https://github.com/chanzuckerberg/lp-design-system/commit/ddbaf648273c6780a73ff1c66ab5d7bac31191a3))
+- **tokens:** add css variables export in json ([c86ac32](https://github.com/chanzuckerberg/lp-design-system/commit/c86ac32c3477cbb67028bcd7a887f1520928853e))
+- **styles:** export Tailwind global styles ([66313dc](https://github.com/chanzuckerberg/lp-design-system/commit/66313dca2cfaaaee6666ef30884b3807867084d1))
+- **button:** add button example with styled-components and twin.macro ([fa8069a](https://github.com/chanzuckerberg/lp-design-system/commit/fa8069ac2f94abe84863e0033488f23f20f6a253))
 
+## [0.0.1-alpha.5](https://github.com/chanzuckerberg/lp-design-system/compare/v0.0.1-alpha.4...v0.0.1-alpha.5) (2020-10-19)
 
+### Features
 
-
+- **tokens:** replace eds token numbers ([59b3552](https://github.com/chanzuckerberg/lp-design-system/commit/59b355274973098315ba0bd531a760c2a0d9499e))
 
 ## [0.0.1-alpha.4](https://github.com/chanzuckerberg/lp-design-system/compare/v0.0.1-alpha.2...v0.0.1-alpha.4) (2020-10-07)
 
-
 ### Features
 
-* **colors:** add eds colors to tokens ([c17a4fa](https://github.com/chanzuckerberg/lp-design-system/commit/c17a4fa084b7e89a587829b2a320e71f82b4a9dc))
-
-
-
-
+- **colors:** add eds colors to tokens ([c17a4fa](https://github.com/chanzuckerberg/lp-design-system/commit/c17a4fa084b7e89a587829b2a320e71f82b4a9dc))
 
 ## 0.0.1-alpha.2 (2020-09-11)
 
-
 ### Bug Fixes
 
-* **pre-push:** fix pre-push tests to use lerna and stream output ([0b59873](https://github.com/chanzuckerberg/lp-design-system/commit/0b5987303ad1399c5c70ce043ba9dae65a1d73d6))
-* **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
-
+- **pre-push:** fix pre-push tests to use lerna and stream output ([0b59873](https://github.com/chanzuckerberg/lp-design-system/commit/0b5987303ad1399c5c70ce043ba9dae65a1d73d6))
+- **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
 
 ### Features
 
-* **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
-* **color:** added intermediate colors ([ee69918](https://github.com/chanzuckerberg/lp-design-system/commit/ee69918c1446bd9860b0d8ef70792790e9951ac2))
-* **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))
-
-
-
-
+- **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
+- **color:** added intermediate colors ([ee69918](https://github.com/chanzuckerberg/lp-design-system/commit/ee69918c1446bd9860b0d8ef70792790e9951ac2))
+- **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))
 
 ## 0.0.1-alpha.1 (2020-07-17)
 
-
 ### Bug Fixes
 
-* **pre-push:** fix pre-push tests to use lerna and stream output ([0b59873](https://github.com/chanzuckerberg/lp-design-system/commit/0b5987303ad1399c5c70ce043ba9dae65a1d73d6))
-* **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
-
+- **pre-push:** fix pre-push tests to use lerna and stream output ([0b59873](https://github.com/chanzuckerberg/lp-design-system/commit/0b5987303ad1399c5c70ce043ba9dae65a1d73d6))
+- **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
 
 ### Features
 
-* **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
-* **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))
-
-
-
-
+- **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
+- **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))
 
 ## 0.0.1-alpha.0 (2020-06-11)
 
-
 ### Bug Fixes
 
-* **pre-push:** fix pre-push tests to use lerna and stream output ([0b59873](https://github.com/chanzuckerberg/lp-design-system/commit/0b5987303ad1399c5c70ce043ba9dae65a1d73d6))
-* **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
-
+- **pre-push:** fix pre-push tests to use lerna and stream output ([0b59873](https://github.com/chanzuckerberg/lp-design-system/commit/0b5987303ad1399c5c70ce043ba9dae65a1d73d6))
+- **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
 
 ### Features
 
-* **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
-* **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))
+- **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
+- **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.1-alpha.5"
+  "version": "0.0.1-alpha.6"
 }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,50 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.1-alpha.6](https://github.com/chanzuckerberg/lp-design-system/compare/v0.0.1-alpha.5...v0.0.1-alpha.6) (2021-01-20)
+
+### Features
+
+- **typography:** add Typography component ([36f5d5c](https://github.com/chanzuckerberg/lp-design-system/commit/36f5d5c9e87e3515f69391426157361c05d523dd))
+- **button:** add button example with styled-components and twin.macro ([fa8069a](https://github.com/chanzuckerberg/lp-design-system/commit/fa8069ac2f94abe84863e0033488f23f20f6a253))
+
 ## [0.0.1-alpha.5](https://github.com/chanzuckerberg/lp-design-system/compare/v0.0.1-alpha.4...v0.0.1-alpha.5) (2020-10-19)
 
 **Note:** Version bump only for package @chanzuckerberg/czedi-kit-components
 
-
-
-
-
 ## [0.0.1-alpha.4](https://github.com/chanzuckerberg/lp-design-system/compare/v0.0.1-alpha.2...v0.0.1-alpha.4) (2020-10-07)
-
 
 ### Features
 
-* **colors:** add eds colors to tokens ([c17a4fa](https://github.com/chanzuckerberg/lp-design-system/commit/c17a4fa084b7e89a587829b2a320e71f82b4a9dc))
-
-
-
-
+- **colors:** add eds colors to tokens ([c17a4fa](https://github.com/chanzuckerberg/lp-design-system/commit/c17a4fa084b7e89a587829b2a320e71f82b4a9dc))
 
 ## 0.0.1-alpha.2 (2020-09-11)
 
-
 ### Features
 
-* **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
-
-
-
-
+- **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
 
 ## 0.0.1-alpha.1 (2020-07-17)
 
-
 ### Features
 
-* **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
-
-
-
-
+- **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
 
 ## 0.0.1-alpha.0 (2020-06-11)
 
-
 ### Features
 
-* **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))
+- **button:** add example button variants with tailwind ([6f6ccd5](https://github.com/chanzuckerberg/lp-design-system/commit/6f6ccd5d4b6adf76374b49cf0a6b1193bd49c4d6))

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-components",
-  "version": "0.0.1-alpha.5",
+  "version": "0.0.1-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5034,11 +5034,6 @@
           "dev": true
         }
       }
-    },
-    "@chanzuckerberg/czedi-kit-tokens": {
-      "version": "0.0.1-alpha.5",
-      "resolved": "https://registry.npmjs.org/@chanzuckerberg/czedi-kit-tokens/-/czedi-kit-tokens-0.0.1-alpha.5.tgz",
-      "integrity": "sha512-jwj4VeiXPxHn5ozigXncvs/+tVKXHeS35c4vfuRN0adwQJDtebgSbjkZQbAUBG7iAtoRqAivPLUNIgpCv5ho4g=="
     },
     "@chanzuckerberg/story-utils": {
       "version": "1.2.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-components",
-  "version": "0.0.1-alpha.5",
+  "version": "0.0.1-alpha.6",
   "description": "React components for czedi-kit",
   "keywords": [
     "design system",
@@ -11,7 +11,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "publishConfig": {
-    "access": "restricted",
+    "access": "public",
     "directory": "dist/",
     "registry": "https://registry.npmjs.org/"
   },
@@ -20,14 +20,14 @@
     "url": "git+https://github.com/chanzuckerberg/lp-design-system.git"
   },
   "scripts": {
-    "build": "npm run build:clean && npm run build:types && npm run build:js",
+    "build": "npm run build:clean && npm run build:types && npm run build:js && rm -rf dist/playground",
     "build:clean": "rm -rf dist/",
     "build:js": "babel src -d dist --extensions '.js,.jsx,.ts,.tsx' --ignore src/**/*.spec.ts,src/**/*.spec.tsx --ignore src/**/*.stories.ts,src/**/*.stories.tsx",
     "build:types": "tsc --project . --declaration --emitDeclarationOnly",
     "build:watch": "npm run build:js -- --watch",
     "build:storybook": "build-storybook -o storybook-static",
     "deploy:docs": "storybook-to-ghpages --ci",
-    "prepack": "npm run build && cp ./package.json dist/",
+    "prepack": "npm run build && cp ./package.json ./tailwind.config.js dist/",
     "snapshot": "percy-storybook --widths=320,1280",
     "storybook": "start-storybook -p 6006",
     "storybook:axe": "npm run build:storybook && npm run storybook:axeOnly",
@@ -43,7 +43,7 @@
     "react": ">= 16.8.0"
   },
   "dependencies": {
-    "@chanzuckerberg/czedi-kit-tokens": "^0.0.1-alpha.5",
+    "@chanzuckerberg/czedi-kit-tokens": "^0.0.1-alpha.6",
     "styled-components": "^5.2.1"
   },
   "devDependencies": {

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -3,69 +3,52 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.0.1-alpha.5](https://github.com/chanzuckerberg/lp-design-system/compare/v0.0.1-alpha.4...v0.0.1-alpha.5) (2020-10-19)
-
+## [0.0.1-alpha.6](https://github.com/chanzuckerberg/lp-design-system/compare/v0.0.1-alpha.5...v0.0.1-alpha.6) (2021-01-20)
 
 ### Features
 
-* **tokens:** replace eds token numbers ([59b3552](https://github.com/chanzuckerberg/lp-design-system/commit/59b355274973098315ba0bd531a760c2a0d9499e))
+- **typography:** add legacy and eds font tokens ([ddbaf64](https://github.com/chanzuckerberg/lp-design-system/commit/ddbaf648273c6780a73ff1c66ab5d7bac31191a3))
+- **tokens:** add css variables export in json ([c86ac32](https://github.com/chanzuckerberg/lp-design-system/commit/c86ac32c3477cbb67028bcd7a887f1520928853e))
 
+## [0.0.1-alpha.5](https://github.com/chanzuckerberg/lp-design-system/compare/v0.0.1-alpha.4...v0.0.1-alpha.5) (2020-10-19)
 
+### Features
 
-
+- **tokens:** replace eds token numbers ([59b3552](https://github.com/chanzuckerberg/lp-design-system/commit/59b355274973098315ba0bd531a760c2a0d9499e))
 
 ## [0.0.1-alpha.4](https://github.com/chanzuckerberg/lp-design-system/compare/v0.0.1-alpha.2...v0.0.1-alpha.4) (2020-10-07)
 
-
 ### Features
 
-* **colors:** add eds colors to tokens ([c17a4fa](https://github.com/chanzuckerberg/lp-design-system/commit/c17a4fa084b7e89a587829b2a320e71f82b4a9dc))
-
-
-
-
+- **colors:** add eds colors to tokens ([c17a4fa](https://github.com/chanzuckerberg/lp-design-system/commit/c17a4fa084b7e89a587829b2a320e71f82b4a9dc))
 
 ## 0.0.1-alpha.2 (2020-09-11)
 
-
 ### Bug Fixes
 
-* **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
-
+- **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
 
 ### Features
 
-* **color:** added intermediate colors ([ee69918](https://github.com/chanzuckerberg/lp-design-system/commit/ee69918c1446bd9860b0d8ef70792790e9951ac2))
-* **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))
-
-
-
-
+- **color:** added intermediate colors ([ee69918](https://github.com/chanzuckerberg/lp-design-system/commit/ee69918c1446bd9860b0d8ef70792790e9951ac2))
+- **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))
 
 ## 0.0.1-alpha.1 (2020-07-17)
 
-
 ### Bug Fixes
 
-* **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
-
+- **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
 
 ### Features
 
-* **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))
-
-
-
-
+- **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))
 
 ## 0.0.1-alpha.0 (2020-06-11)
 
-
 ### Bug Fixes
 
-* **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
-
+- **tokens:** replace heading sizes with t-shirt sizes ([4fb40b5](https://github.com/chanzuckerberg/lp-design-system/commit/4fb40b5cdf524c34d7ab124b153ad82628430439))
 
 ### Features
 
-* **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))
+- **tokens:** add real tokens based on legacy styles ([fba7713](https://github.com/chanzuckerberg/lp-design-system/commit/fba7713f665737efde153ccf92fbe9447b2af22f))

--- a/packages/tokens/package-lock.json
+++ b/packages/tokens/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-tokens",
-  "version": "0.0.1-alpha.5",
+  "version": "0.0.1-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/czedi-kit-tokens",
-  "version": "0.0.1-alpha.5",
+  "version": "0.0.1-alpha.6",
   "description": "Design tokens czedi-kit packages",
   "keywords": [
     "design",


### PR DESCRIPTION
### Summary:
[CH task](https://app.clubhouse.io/czi-edu/story/65420/ds-publish-typography-component)

Publishing typography component to start traject migration. Also snuck in the [tailwind config export](https://app.clubhouse.io/czi-edu/story/62334/ds-prep-tailwind-config-for-export)

### Test Plan:
Run `npx lerna run prepack`, confirm:
- packages/tokens/dist includes `json/css-variables-nested.json`
- packages/components/dist includes
![Screen Shot 2021-01-20 at 5 49 07 PM](https://user-images.githubusercontent.com/15840841/105250704-3632bd80-5b48-11eb-9ad9-75419846c06f.png)
