### PR TITLE
chore: update package-lock and publishing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # lp-design-system
+
 ![Test CI](https://github.com/chanzuckerberg/lp-design-system/workflows/Test%20CI/badge.svg)
 
 This is the Learning Platform Design System or `@chanzuckerberg/czedi-kit` (working title).
@@ -32,7 +33,7 @@ npm run lint:fix
 
 ### Run Locally
 
-```
+```bash
 npm start
 ```
 
@@ -56,4 +57,32 @@ npx lerna create '@chanzuckerberg/czedi-kit-<package-name>' \
 
 ### Publishing
 
-We're not ready to publish yet
+**We are only publishing alpha pre-releases at this time**
+
+1. Confirm that all checks are green on CI.
+2. Run `git checkout master`
+3. Increment `<version>` based on the latest alpha version:
+
+```bash
+npx lerna version --no-push --conventional-commits --cd-version prerelease --message "chore(release): publish v0.0.1-alpha.<version>"
+```
+
+`--no-push` ensures the commit is not auto-pushed to remote git.
+
+3. Run
+
+```bash
+npx lerna publish from-git --no-push
+```
+
+and confirm that tags/commit/changelog etc. look correct
+
+4. Push commit and tags to remote:
+
+```bash
+git push origin --tags && git push origin master
+```
+
+In the future, we should have a `publish` script to handle all of this 🤓
+
+You could also try directly running `lerna publish --canary --preid alpha`, though this gives a commit message that doesn't follow our lint rule for conventional commits.

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -5035,6 +5035,11 @@
         }
       }
     },
+    "@chanzuckerberg/czedi-kit-tokens": {
+      "version": "0.0.1-alpha.6",
+      "resolved": "https://registry.npmjs.org/@chanzuckerberg/czedi-kit-tokens/-/czedi-kit-tokens-0.0.1-alpha.6.tgz",
+      "integrity": "sha512-iYxGjr9AwK8Aicc16sqpFJPry0eCPUa7qXgC+xAUraogGRhbOTKj8ptIbd2DzgEZlWxwgF3KveMJ2/jKcTEG8Q=="
+    },
     "@chanzuckerberg/story-utils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@chanzuckerberg/story-utils/-/story-utils-1.2.0.tgz",


### PR DESCRIPTION
### Summary:
I did some silly stuff while trying to publish version alpha.6, including manually changing package-lock.json 😅 

### Test Plan:
n/a